### PR TITLE
Add route layer

### DIFF
--- a/src/main/kotlin/no/nav/emottak/App.kt
+++ b/src/main/kotlin/no/nav/emottak/App.kt
@@ -4,6 +4,7 @@ import arrow.continuations.SuspendApp
 import arrow.continuations.ktor.server
 import arrow.core.raise.result
 import arrow.fx.coroutines.resourceScope
+import io.ktor.client.HttpClient
 import io.ktor.server.application.Application
 import io.ktor.server.netty.Netty
 import io.micrometer.prometheus.PrometheusMeterRegistry
@@ -26,7 +27,7 @@ fun main() = SuspendApp {
                 Netty,
                 port = config().server.port.value,
                 preWait = config().server.preWait,
-                module = ediAdapterModule(deps.meterRegistry)
+                module = ediAdapterModule(deps.httpClient, deps.meterRegistry)
             )
 
             awaitCancellation()
@@ -36,12 +37,13 @@ fun main() = SuspendApp {
 }
 
 internal fun ediAdapterModule(
+    ediClient: HttpClient,
     meterRegistry: PrometheusMeterRegistry
 ): Application.() -> Unit {
     return {
         configureMetrics(meterRegistry)
         configureContentNegotiation()
-        configureRoutes(meterRegistry)
+        configureRoutes(ediClient, meterRegistry)
         configureCallLogging()
     }
 }

--- a/src/main/kotlin/no/nav/emottak/Error.kt
+++ b/src/main/kotlin/no/nav/emottak/Error.kt
@@ -1,0 +1,42 @@
+package no.nav.emottak
+
+import io.ktor.http.ContentType.Text.Plain
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.HttpStatusCode.Companion.BadRequest
+import io.ktor.http.content.TextContent
+
+sealed interface MessageError
+sealed interface ValidationError : MessageError
+
+data object MessageIdEmpty : ValidationError
+data object MessageIdsMissing : ValidationError
+data object MessageIdsEmpty : ValidationError
+data object HerIdEmpty : ValidationError
+data object SenderHerIdMissing : ValidationError
+data object SenderHerIdEmpty : ValidationError
+
+fun MessageError.toContent(): TextContent =
+    when (this) {
+        is MessageIdEmpty ->
+            TextContent("Message id is empty")
+
+        is MessageIdsMissing ->
+            TextContent("Message ids are missing")
+
+        is MessageIdsEmpty ->
+            TextContent("Message ids are empty")
+
+        is HerIdEmpty ->
+            TextContent("Her id is empty")
+
+        is SenderHerIdMissing ->
+            TextContent("Sender her id is missing")
+
+        is SenderHerIdEmpty ->
+            TextContent("Sender her id is empty")
+    }
+
+private fun TextContent(
+    content: String,
+    statusCode: HttpStatusCode = BadRequest
+): TextContent = TextContent(content, Plain, statusCode)

--- a/src/main/kotlin/no/nav/emottak/Validation.kt
+++ b/src/main/kotlin/no/nav/emottak/Validation.kt
@@ -1,0 +1,32 @@
+package no.nav.emottak
+
+import arrow.core.raise.Raise
+import arrow.core.raise.ensure
+import arrow.core.raise.ensureNotNull
+import io.ktor.server.application.ApplicationCall
+
+private const val ID = "id"
+private const val MESSAGE_ID = "messageId"
+private const val HER_ID = "herId"
+private const val APP_REC_SENDER_HER_ID = "apprecSenderHerId"
+
+fun Raise<ValidationError>.messageId(call: ApplicationCall): String =
+    call.parameters[MESSAGE_ID]!!.also {
+        ensure(it.isNotBlank()) { MessageIdEmpty }
+    }
+
+fun Raise<ValidationError>.herId(call: ApplicationCall): String =
+    call.parameters[HER_ID]!!.also {
+        ensure(it.isNotBlank()) { HerIdEmpty }
+    }
+
+fun Raise<ValidationError>.senderHerId(call: ApplicationCall): String =
+    call.parameters[APP_REC_SENDER_HER_ID]!!.also {
+        ensure(it.isNotBlank()) { SenderHerIdEmpty }
+    }
+
+fun Raise<ValidationError>.messageIds(call: ApplicationCall): List<String> =
+    ensureNotNull(call.request.queryParameters.getAll(ID)) { MessageIdsMissing }
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+        .also { ensure(it.isNotEmpty()) { MessageIdsEmpty } }

--- a/src/main/kotlin/no/nav/emottak/edi/adapter/config/Config.kt
+++ b/src/main/kotlin/no/nav/emottak/edi/adapter/config/Config.kt
@@ -8,7 +8,7 @@ data class Config(
     val azureAuth: AzureAuth,
     val server: Server,
     val httpClient: HttpClient,
-    val httpTokenClient: HttpClient
+    val httpTokenClient: HttpTokenClient
 )
 
 data class Nhn(
@@ -51,9 +51,23 @@ data class AzureAuth(
     value class ClientAssertionType(val value: String)
 }
 
+@JvmInline
+value class Timeout(val value: Long)
+
 data class HttpClient(
-    val connectionTimeout: Timeout
+    val connectionTimeout: Timeout,
+    val apiVersionHeader: ApiVersionHeader,
+    val sourceSystemHeader: SourceSystemHeader,
+    val acceptTypeHeader: AcceptTypeHeader
 ) {
     @JvmInline
-    value class Timeout(val value: Long)
+    value class ApiVersionHeader(val value: String)
+
+    @JvmInline
+    value class SourceSystemHeader(val value: String)
+
+    @JvmInline
+    value class AcceptTypeHeader(val value: String)
 }
+
+data class HttpTokenClient(val connectionTimeout: Timeout)

--- a/src/main/kotlin/no/nav/emottak/edi/adapter/model/AppRec.kt
+++ b/src/main/kotlin/no/nav/emottak/edi/adapter/model/AppRec.kt
@@ -1,0 +1,9 @@
+package no.nav.emottak.edi.adapter.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AppRec(
+    val appRecStatus: String = "1",
+    val appRecErrorList: List<AppRecError> = emptyList()
+)

--- a/src/main/kotlin/no/nav/emottak/edi/adapter/model/AppRecError.kt
+++ b/src/main/kotlin/no/nav/emottak/edi/adapter/model/AppRecError.kt
@@ -1,0 +1,11 @@
+package no.nav.emottak.edi.adapter.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AppRecError(
+    val errorCode: String,
+    val details: String,
+    val description: String,
+    val oid: String
+)

--- a/src/main/kotlin/no/nav/emottak/edi/adapter/model/Message.kt
+++ b/src/main/kotlin/no/nav/emottak/edi/adapter/model/Message.kt
@@ -1,0 +1,12 @@
+package no.nav.emottak.edi.adapter.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Message(
+    val messageType: String,
+    val recipient: String,
+    val businessDocument: String,
+    val contentType: String = "application/xml",
+    val contentTransferEncoding: String = "base64"
+)

--- a/src/main/kotlin/no/nav/emottak/edi/adapter/plugin/Routes.kt
+++ b/src/main/kotlin/no/nav/emottak/edi/adapter/plugin/Routes.kt
@@ -1,21 +1,45 @@
 package no.nav.emottak.edi.adapter.plugin
 
+import arrow.core.raise.recover
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType.Application.Json
+import io.ktor.http.contentType
+import io.ktor.http.parametersOf
 import io.ktor.server.application.Application
+import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondText
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import io.micrometer.prometheus.PrometheusMeterRegistry
+import no.nav.emottak.MessageError
+import no.nav.emottak.edi.adapter.model.AppRec
+import no.nav.emottak.edi.adapter.model.Message
+import no.nav.emottak.herId
+import no.nav.emottak.messageId
+import no.nav.emottak.messageIds
+import no.nav.emottak.senderHerId
+import no.nav.emottak.toContent
+
+private const val RECEIVER_HER_IDS = "ReceiverHerIds"
 
 fun Application.configureRoutes(
+    ediClient: HttpClient,
     registry: PrometheusMeterRegistry
 ) {
     routing {
         internalRoutes(registry)
         // authenticate(config.azureAuth.azureAdAuth.value) {
-        externalRoutes()
+        externalRoutes(ediClient)
         // }
     }
 }
@@ -34,10 +58,76 @@ fun Route.internalRoutes(registry: PrometheusMeterRegistry) {
     }
 }
 
-fun Route.externalRoutes() {
-    route("/api") {
-        get("/edi/adapter") {
-            call.respondText("Pong from emottak-edi-adapter")
+fun Route.externalRoutes(ediClient: HttpClient) {
+    route("/api/v1") {
+        get("/messages") {
+            recover({
+                val messageIds = messageIds(call)
+                val params = parametersOf(RECEIVER_HER_IDS to messageIds)
+                val response = ediClient.get("Messages") { url { parameters.appendAll(params) } }
+                call.respond(response.bodyAsText())
+            }) { e: MessageError -> call.respond(e.toContent()) }
+        }
+        get("/messages/{messageId}") {
+            recover({
+                val messageId = messageId(call)
+                val response = ediClient.get("Messages/$messageId")
+                call.respond(response.bodyAsText())
+            }) { e: MessageError -> call.respond(e.toContent()) }
+        }
+
+        get("/messages/{messageId}/document") {
+            recover({
+                val messageId = messageId(call)
+                val response = ediClient.get("Messages/$messageId/business-document")
+                call.respond(response.bodyAsText())
+            }) { e: MessageError -> call.respond(e.toContent()) }
+        }
+
+        get("/messages/{messageId}/status") {
+            recover({
+                val messageId = messageId(call)
+                val response = ediClient.get("Messages/$messageId/status")
+                call.respond(response.bodyAsText())
+            }) { e: MessageError -> call.respond(e.toContent()) }
+        }
+        get("/messages/{messageId}/apprec") {
+            recover({
+                val messageId = messageId(call)
+                val response = ediClient.get("Messages/$messageId/apprec")
+                call.respond(response.bodyAsText())
+            }) { e: MessageError -> call.respond(e.toContent()) }
+        }
+        post("/messages") {
+            val message = call.receive<Message>()
+            val response = ediClient.post("Messages") {
+                contentType(Json)
+                setBody(message)
+            }
+            call.respond(response.bodyAsText())
+        }
+
+        post("/messages/{messageId}/apprec/{apprecSenderHerId}") {
+            recover({
+                val messageId = messageId(call)
+                val senderHerId = senderHerId(call)
+                val appRec = call.receive<AppRec>()
+
+                val response = ediClient.post("Messages/$messageId/apprec/$senderHerId") {
+                    contentType(Json)
+                    setBody(appRec)
+                }
+                call.respond(response.bodyAsText())
+            }) { e: MessageError -> call.respond(e.toContent()) }
+        }
+
+        put("/messages/{messageId}/read/{herId}") {
+            recover({
+                val messageId = messageId(call)
+                val herId = herId(call)
+                val response = ediClient.put("/messages/$messageId/read/$herId")
+                call.respond(response.status.value)
+            }) { e: MessageError -> call.respond(e.toContent()) }
         }
     }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -13,6 +13,9 @@ server {
 httpClient {
   // should be < server pre wait
   connectionTimeout = 3000
+  apiVersionHeader = "2"
+  sourceSystemHeader = "eMottak EDI 2.0 edi-adapter, v1.0"
+  acceptTypeHeader = "application/json"
 }
 
 httpTokenClient {

--- a/src/test/kotlin/no/nav/emottak/edi/adapter/plugin/RoutesSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/edi/adapter/plugin/RoutesSpec.kt
@@ -1,0 +1,332 @@
+package no.nav.emottak.edi.adapter.plugin
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeIn
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType.Application.Json
+import io.ktor.http.HttpStatusCode.Companion.BadRequest
+import io.ktor.http.HttpStatusCode.Companion.NoContent
+import io.ktor.http.HttpStatusCode.Companion.NotFound
+import io.ktor.http.HttpStatusCode.Companion.OK
+import io.ktor.http.content.TextContent
+import io.ktor.http.contentType
+import io.ktor.http.fullPath
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.testing.TestApplicationBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.text.Charsets.UTF_8
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+
+class RoutesSpec : StringSpec(
+    {
+        "GET /messages returns EDI response" {
+            val ediClient = fakeEdiClient {
+                it.url.fullPath shouldBe "/Messages?ReceiverHerIds=1"
+                respond("""[{"id":"1"}]""")
+            }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.get("/api/v1/messages?id=1")
+
+                response.status shouldBe OK
+                response.bodyAsText() shouldBe """[{"id":"1"}]"""
+            }
+        }
+
+        "GET /messages with blank id returns 400" {
+            val ediClient = fakeEdiClient { error("Should not be called") }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.get("/api/v1/messages?id=")
+                response.status shouldBe BadRequest
+                response.bodyAsText() shouldContain "Message ids"
+            }
+        }
+
+        "GET /messages without id returns 400" {
+            val ediClient = fakeEdiClient { error("Should not be called") }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.get("/api/v1/messages")
+
+                response.status shouldBe BadRequest
+                response.bodyAsText() shouldContain "Message ids"
+            }
+        }
+
+        "GET /messages/{id} returns EDI response" {
+            val ediClient = fakeEdiClient { request ->
+                request.url.fullPath shouldBe "/Messages/42"
+                respond("OK")
+            }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.get("/api/v1/messages/42")
+
+                response.status shouldBe OK
+                response.bodyAsText() shouldBe "OK"
+            }
+        }
+
+        "GET /messages/{id} with blank id returns 400" {
+            val ediClient = fakeEdiClient { error("Should not be called") }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.get("/api/v1/messages/%20")
+
+                response.status shouldBe BadRequest
+                response.bodyAsText() shouldContain "Message id"
+            }
+        }
+
+        "GET /messages/{id} missing id returns 404" {
+            val ediClient = fakeEdiClient { error("Should not be called") }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.get("/api/v1/messages/")
+
+                response.status shouldBe NotFound
+            }
+        }
+
+        "GET /messages/{id}/document returns EDI response" {
+            val ediClient = fakeEdiClient { request ->
+                request.url.fullPath shouldBe "/Messages/99/business-document"
+                respond("<xml>doc</xml>")
+            }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.get("/api/v1/messages/99/document")
+
+                response.status shouldBe OK
+                response.bodyAsText() shouldBe "<xml>doc</xml>"
+            }
+        }
+
+        "GET /messages/{id}/status returns EDI response" {
+            val ediClient = fakeEdiClient { request ->
+                request.url.fullPath shouldBe "/Messages/55/status"
+                respond("""{"status":"READ"}""")
+            }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.get("/api/v1/messages/55/status")
+
+                response.status shouldBe OK
+                response.bodyAsText() shouldBe """{"status":"READ"}"""
+            }
+        }
+
+        "GET /messages/{id}/apprec returns EDI response" {
+            val ediClient = fakeEdiClient { request ->
+                request.url.fullPath shouldBe "/Messages/10/apprec"
+                respond("""{"apprec":"OK"}""")
+            }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.get("/api/v1/messages/10/apprec")
+
+                response.status shouldBe OK
+                response.bodyAsText() shouldBe """{"apprec":"OK"}"""
+            }
+        }
+
+        "POST /messages forwards body to EDI" {
+            val ediClient = fakeEdiClient { request ->
+                request.url.fullPath shouldBe "/Messages"
+                (request.body as TextContent).text shouldContain "HealthInformation"
+                respond("""{"result":"created"}""")
+            }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val message =
+                    """
+                {
+                  "messageType":"HealthInformation",
+                  "recipient":"mottak-qass@test-es.nav.no",
+                  "businessDocument": ${base64EncodedDocument()}
+                }
+                """
+
+                val response = client.post("/api/v1/messages") {
+                    contentType(Json)
+                    setBody(message)
+                }
+
+                response.status shouldBe OK
+                response.bodyAsText() shouldBe """{"result":"created"}"""
+            }
+        }
+
+        "POST /messages with empty body returns 400 or 415" {
+            val ediClient = fakeEdiClient { error("Should not be called") }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.post("/api/v1/messages") {
+                    contentType(Json)
+                    setBody("")
+                }
+                response.status.value shouldBeIn listOf(400, 415)
+            }
+        }
+
+        "POST /messages/{id}/apprec/{sender} forwards body" {
+            val ediClient = fakeEdiClient { request ->
+                request.url.fullPath shouldBe "/Messages/77/apprec/8142"
+                (request.body as TextContent).text shouldContain "1"
+                respond("""{"status":"ok"}""")
+            }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val apprecBody = """{ "appRecStatus":"1", "appRecErrorList":[] }"""
+
+                val response = client.post("/api/v1/messages/77/apprec/8142") {
+                    contentType(Json)
+                    setBody(apprecBody)
+                }
+
+                response.status shouldBe OK
+                response.bodyAsText() shouldBe """{"status":"ok"}"""
+            }
+        }
+
+        "POST /messages/{id}/apprec/{sender} with blank sender returns 400" {
+            val ediClient = fakeEdiClient { error("Should not be called") }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.post("/api/v1/messages/77/apprec/%20") {
+                    contentType(Json)
+                    setBody("""{ "appRecStatus":"1", "appRecErrorList":[] }""")
+                }
+
+                response.status shouldBe BadRequest
+                response.bodyAsText() shouldContain "Sender"
+            }
+        }
+
+        "POST /messages/{id}/apprec missing sender returns 404" {
+            val ediClient = fakeEdiClient { error("Should not be called") }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.post("/api/v1/messages/77/apprec/") {
+                    contentType(Json)
+                    setBody("""{"status":"1"}""")
+                }
+                response.status shouldBe NotFound
+            }
+        }
+
+        "PUT /messages/{id}/read/{herId} marks message as read" {
+            val ediClient = fakeEdiClient { request ->
+                request.url.fullPath shouldBe "/messages/5/read/111"
+                respond("", status = NoContent)
+            }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.put("/api/v1/messages/5/read/111")
+
+                response.status shouldBe OK
+            }
+        }
+
+        "PUT /messages/{id}/read/{herId} with blank herId returns 400" {
+            val ediClient = fakeEdiClient { error("Should not be called") }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.put("/api/v1/messages/5/read/%20")
+
+                response.status shouldBe BadRequest
+                response.bodyAsText() shouldContain "Her id"
+            }
+        }
+
+        "PUT /messages/{id}/read missing herId returns 404" {
+            val ediClient = fakeEdiClient { error("Should not be called") }
+
+            testApplication {
+                installExternalRoutes(ediClient)
+
+                val response = client.put("/api/v1/messages/5/read/")
+
+                response.status shouldBe NotFound
+            }
+        }
+    }
+)
+
+private fun TestApplicationBuilder.installExternalRoutes(ediClient: HttpClient) {
+    install(ContentNegotiation) { json() }
+    routing { externalRoutes(ediClient) }
+}
+
+private fun fakeEdiClient(
+    handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData
+) = HttpClient(MockEngine) {
+    engine {
+        addHandler(handler)
+    }
+    install(ClientContentNegotiation) {
+        json(
+            Json {
+                ignoreUnknownKeys = true
+                encodeDefaults = true
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalEncodingApi::class)
+private fun base64EncodedDocument(): String =
+    Base64.encode(
+        """"<MsgHead><Body>hello world</Body></MsgHead>""""
+            .trimIndent()
+            .toByteArray(UTF_8)
+    )


### PR DESCRIPTION
All routes within the EDI Messages API have been implemented through the adapter. There are some optional parameters that as of now aren't being passed through but all major functionality is supported.

Initially, the adapter is more of a convenience layer on top of EDI but this may change as it evolves. 

The tests are a good starting point for understanding how the _routes_ are mapped. 

When merged and deployed a nice way of verifying the API is ie posting an actual business document (fagmelding).

For example, the following when executed in the adapter pod in the cluster will do exactly that:

```
curl -X POST "http://localhost:8080/api/v1/messages" \
  -H "Content-Type: application/json" \
  -d '{
    "messageType": "HealthInformation",
    "recipient": "mottak-qass@test-es.nav.no",
    "businessDocument": "<base64 encoded string of the document>"
  }'
```