### PR TITLE
Parse json secret

### DIFF
--- a/src/main/kotlin/no/nav/emottak/edi/adapter/util/JWTUtil.kt
+++ b/src/main/kotlin/no/nav/emottak/edi/adapter/util/JWTUtil.kt
@@ -15,6 +15,9 @@ import com.nimbusds.openid.connect.sdk.Nonce
 import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet.NONCE_CLAIM_NAME
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpMethod.Companion.Post
+import net.minidev.json.JSONObject
+import net.minidev.json.parser.JSONParser
+import net.minidev.json.parser.JSONParser.MODE_PERMISSIVE
 import no.nav.emottak.config
 import no.nav.emottak.edi.adapter.config.AzureAuth
 import java.net.URI
@@ -22,11 +25,9 @@ import java.security.MessageDigest.getInstance
 import java.time.Instant.now
 import java.util.Base64.getUrlEncoder
 import java.util.Date.from
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.uuid.Uuid
 
-private val keyPair = RSAKey.parse(decodeKeypair(config().nhn.keyPair.value))
+private val keyPair = RSAKey.parse(parsePair(config().nhn.keyPair.value))
 
 fun dpopProofWithoutNonce(): String =
     dpopProof(
@@ -141,5 +142,4 @@ private fun Builder.ath(accessToken: DPoPAccessToken?) =
 private fun Builder.nonce(nonce: Nonce?) =
     apply { nonce?.let { claim(NONCE_CLAIM_NAME, it.value) } }
 
-@OptIn(ExperimentalEncodingApi::class)
-private fun decodeKeypair(keypair: String): String = Base64.decode(keypair).decodeToString()
+private fun parsePair(keypair: String): JSONObject = JSONParser(MODE_PERMISSIVE).parse(keypair) as JSONObject

--- a/src/test/kotlin/no/nav/emottak/TestUtil.kt
+++ b/src/test/kotlin/no/nav/emottak/TestUtil.kt
@@ -6,9 +6,6 @@ import com.nimbusds.jose.jwk.KeyUse.SIGNATURE
 import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
 import java.util.Date
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
-import kotlin.text.Charsets.UTF_8
 
 val generateRsaJwk: () -> RSAKey = {
     RSAKeyGenerator(2048)
@@ -18,6 +15,3 @@ val generateRsaJwk: () -> RSAKey = {
         .generate()
 }
     .memoize()
-
-@OptIn(ExperimentalEncodingApi::class)
-fun RSAKey.base64Encoded(): String = Base64.encode(toJSONString().toByteArray(UTF_8))

--- a/src/test/kotlin/no/nav/emottak/edi/adapter/plugin/DpopAuthSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/edi/adapter/plugin/DpopAuthSpec.kt
@@ -15,7 +15,6 @@ import io.ktor.http.HttpMethod.Companion.Get
 import io.ktor.http.HttpStatusCode.Companion.OK
 import io.ktor.http.headersOf
 import kotlinx.datetime.Clock
-import no.nav.emottak.base64Encoded
 import no.nav.emottak.config
 import no.nav.emottak.edi.adapter.model.DpopTokens
 import no.nav.emottak.generateRsaJwk
@@ -26,7 +25,7 @@ class DpopAuthSpec : StringSpec(
         val rsaJwk = generateRsaJwk()
 
         "should fetch token if none is cached and add headers" {
-            withEnvironment("emottak-nhn-edi", rsaJwk.base64Encoded()) {
+            withEnvironment("emottak-nhn-edi", rsaJwk.toString()) {
                 val apiUrl = "https://api.test/Messages"
 
                 val dummyTokens = DpopTokens(

--- a/src/test/kotlin/no/nav/emottak/edi/adapter/util/DpopTokenUtilSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/edi/adapter/util/DpopTokenUtilSpec.kt
@@ -16,17 +16,16 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
-import no.nav.emottak.base64Encoded
 import no.nav.emottak.config
 import no.nav.emottak.generateRsaJwk
 
 class DpopTokenUtilSpec : StringSpec(
     {
         val rsaJwk = generateRsaJwk()
-        val rsaJwkBase64 = rsaJwk.base64Encoded()
+        val rsaJwkJson = rsaJwk.toString()
 
         "should return tokens immediately if first call is 200" {
-            withEnvironment("emottak-nhn-edi", rsaJwkBase64) {
+            withEnvironment("emottak-nhn-edi", rsaJwkJson) {
                 val config = config().azureAuth
 
                 val engine = MockEngine { _ ->
@@ -55,7 +54,7 @@ class DpopTokenUtilSpec : StringSpec(
         }
 
         "should retry with nonce if first call returns 400" {
-            withEnvironment("emottak-nhn-edi", rsaJwkBase64) {
+            withEnvironment("emottak-nhn-edi", rsaJwkJson) {
                 val config = config().azureAuth
                 var callCount = 0
                 val engine = MockEngine { _ ->
@@ -91,7 +90,7 @@ class DpopTokenUtilSpec : StringSpec(
         }
 
         "should throw if final response is not 200" {
-            withEnvironment("emottak-nhn-edi", rsaJwkBase64) {
+            withEnvironment("emottak-nhn-edi", rsaJwkJson) {
                 val config = config().azureAuth
 
                 val engine = MockEngine { _ ->

--- a/src/test/kotlin/no/nav/emottak/edi/adapter/util/JWTUtilSpec.kt
+++ b/src/test/kotlin/no/nav/emottak/edi/adapter/util/JWTUtilSpec.kt
@@ -14,7 +14,6 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.http.HttpMethod.Companion.Get
 import io.ktor.http.HttpMethod.Companion.Post
-import no.nav.emottak.base64Encoded
 import no.nav.emottak.config
 import no.nav.emottak.generateRsaJwk
 import java.net.URI
@@ -24,10 +23,10 @@ import kotlin.uuid.Uuid
 class JWTUtilSpec : StringSpec(
     {
         val rsaJwk = generateRsaJwk()
-        val rsaJwkBase64 = rsaJwk.base64Encoded()
+        val rsaJwkJson = rsaJwk.toString()
 
         "should generate valid DPoP proof and required claims without nonce" {
-            withEnvironment("emottak-nhn-edi", rsaJwkBase64) {
+            withEnvironment("emottak-nhn-edi", rsaJwkJson) {
                 val config = config()
 
                 println("KEY from env: ${config.nhn.keyPair.value}")
@@ -46,7 +45,7 @@ class JWTUtilSpec : StringSpec(
         }
 
         "should generate valid DPoP proof and required claims with nonce" {
-            withEnvironment("emottak-nhn-edi", rsaJwkBase64) {
+            withEnvironment("emottak-nhn-edi", rsaJwkJson) {
                 val config = config().azureAuth
 
                 val random = Uuid.random()
@@ -65,7 +64,7 @@ class JWTUtilSpec : StringSpec(
         }
 
         "should generate valid DPoP proof and required claims with access token" {
-            withEnvironment("emottak-nhn-edi", rsaJwkBase64) {
+            withEnvironment("emottak-nhn-edi", rsaJwkJson) {
                 val uri = URI("https://my.uri.com")
                 val accessToken = DPoPAccessToken("my access token")
 


### PR DESCRIPTION
The secret is automatically decoded from base64 so no need to decode. Instead we need to parse the jwk properly as json and pass it along.