### PR TITLE
Fix service name in ingress

### DIFF
--- a/.nais/edi-adapter-dev.yaml
+++ b/.nais/edi-adapter-dev.yaml
@@ -53,7 +53,7 @@ spec:
       cpu: "200m"
       memory: "512Mi"
   ingresses:
-    - "https://edi-transport.intern.dev.nav.no"
+    - "https://edi-adapter.intern.dev.nav.no"
   filesFrom:
     - secret: emottak-nhn-edi
       mountPath: /var/run/secrets/emottak-nhn-edi


### PR DESCRIPTION
There is probably a copy / paste error in the current ingress since it should be `edi-adapter` in favour of `edi-transport`.