### PR TITLE
#307 Bli kvitt emotak-utils avhengigheten i emottak-edi-adapter

### DIFF
--- a/edi-adapter-server/build.gradle.kts
+++ b/edi-adapter-server/build.gradle.kts
@@ -62,7 +62,6 @@ dependencies {
     implementation(libs.ktor.server.netty)
     implementation(libs.kotlin.logging)
     implementation(libs.token.validation.ktor.v3)
-    implementation(libs.emottak.utils)
     testImplementation(testLibs.bundles.kotest)
     testImplementation(testLibs.kotest.assertions.arrow)
     testImplementation(testLibs.kotest.extensions.jvm)

--- a/edi-adapter-server/src/main/kotlin/no/nav/emottak/ediadapter/server/config/Config.kt
+++ b/edi-adapter-server/src/main/kotlin/no/nav/emottak/ediadapter/server/config/Config.kt
@@ -1,8 +1,8 @@
 package no.nav.emottak.ediadapter.server.config
 
 import io.ktor.client.plugins.logging.LogLevel
-import no.nav.emottak.utils.config.Server
 import java.net.URI
+import kotlin.time.Duration
 
 data class Config(
     val nhn: Nhn,
@@ -12,6 +12,14 @@ data class Config(
     val httpTokenClient: HttpTokenClient,
     val azureAuth: AzureAuth
 )
+
+data class Server(
+    val port: Port,
+    val preWait: Duration
+)
+
+@JvmInline
+value class Port(val value: Int)
 
 data class Nhn(
     val baseUrl: URI,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,7 +24,6 @@ dependencyResolutionManagement {
             version("logback", "1.5.19")
             version("logstash", "7.4")
             version("kotlinx-serialization", "1.9.0")
-            version("emottak-utils", "0.3.5.dev15")
 
             library("arrow-core", "io.arrow-kt", "arrow-core").versionRef("arrow")
             library("arrow-functions", "io.arrow-kt", "arrow-functions").versionRef("arrow")
@@ -69,8 +68,6 @@ dependencyResolutionManagement {
             ).versionRef("token-validation-ktor")
 
             library("kotlinx-serialization-json", "org.jetbrains.kotlinx", "kotlinx-serialization-json").versionRef("kotlinx-serialization")
-
-            library("emottak-utils", "no.nav.emottak", "emottak-utils").versionRef("emottak-utils")
 
             bundle("prometheus", listOf("ktor-server-metrics-micrometer", "micrometer-registry-prometheus"))
             bundle("logging", listOf("logback-classic", "logback-logstash"))


### PR DESCRIPTION
Flyttet `Server` konfigurasjon fra` emottak-utils`.

Oppgave: https://github.com/navikt/team-emottak-docs/issues/307
