### PR TITLE
Add default edi adapter server url

### DIFF
--- a/edi-adapter-client/src/main/kotlin/no/nav/emottak/ediadapter/client/Config.kt
+++ b/edi-adapter-client/src/main/kotlin/no/nav/emottak/ediadapter/client/Config.kt
@@ -1,11 +1,13 @@
 package no.nav.emottak.ediadapter.client
 
+import java.net.URL
 import java.time.Duration
 
 internal data class Config(
     val auth: AzureAuth,
     val httpClient: HttpClient,
-    val httpTokenClient: HttpClient
+    val httpTokenClient: HttpClient,
+    val ediAdapterServer: EdiAdapterServer
 ) {
     data class AzureAuth(
         val azureGrantType: AzureGrantType,
@@ -28,5 +30,9 @@ internal data class Config(
 
     data class HttpClient(
         val connectionTimeout: Duration
+    )
+
+    data class EdiAdapterServer(
+        val url: URL
     )
 }

--- a/edi-adapter-client/src/main/kotlin/no/nav/emottak/ediadapter/client/EdiAdapterClient.kt
+++ b/edi-adapter-client/src/main/kotlin/no/nav/emottak/ediadapter/client/EdiAdapterClient.kt
@@ -26,8 +26,8 @@ import kotlin.uuid.Uuid
 private val log = KotlinLogging.logger {}
 
 class EdiAdapterClient(
-    private val ediAdapterUrl: String,
-    clientProvider: () -> HttpClient
+    clientProvider: () -> HttpClient,
+    private val ediAdapterUrl: String = config().ediAdapterServer.url.toString()
 ) {
     private var httpClient = clientProvider.invoke()
 
@@ -86,7 +86,11 @@ class EdiAdapterClient(
         return handleResponse(response)
     }
 
-    suspend fun postApprec(id: Uuid, apprecSenderHerId: Int, postAppRecRequest: PostAppRecRequest): Pair<String?, ErrorMessage?> {
+    suspend fun postApprec(
+        id: Uuid,
+        apprecSenderHerId: Int,
+        postAppRecRequest: PostAppRecRequest
+    ): Pair<String?, ErrorMessage?> {
         val url = "$ediAdapterUrl/api/v1/messages/$id/apprec/$apprecSenderHerId"
         val response = httpClient.post(url) {
             contentType(ContentType.Application.Json)

--- a/edi-adapter-client/src/main/resources/edi-adapter-client.conf
+++ b/edi-adapter-client/src/main/resources/edi-adapter-client.conf
@@ -7,6 +7,10 @@ httpTokenClient {
   connectionTimeout = "${TOKEN_CLIENT_TIMEOUT_IN_SECONDS:-2}s"
 }
 
+ediAdapterServer {
+  url = "http://edi-adapter"
+}
+
 azureAuth {
   azureGrantType = "client_credentials"
   azureTokenEndpoint = "${AZURE_OPENID_CONFIG_TOKEN_ENDPOINT:-http://localhost:3344/AZURE_AD/token}"


### PR DESCRIPTION
- This offloads the actual server url to Hoplite for flexibility and type safety
- Using the [service discovery](https://docs.nais.io/workloads/application/explanations/expose/#service-discovery) address as default since this will only be used by internal services
- Re-arranged the constructor parameters so the edi client can be instantiated as:  
`val client = EdiAdapterClient(scopedClient)`