### PR TITLE
Fix kotlinx deserialization

### DIFF
--- a/edi-adapter-model/src/main/kotlin/no/nav/helsemelding/ediadapter/model/DeliveryState.kt
+++ b/edi-adapter-model/src/main/kotlin/no/nav/helsemelding/ediadapter/model/DeliveryState.kt
@@ -1,12 +1,20 @@
 package no.nav.helsemelding.ediadapter.model
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 enum class DeliveryState(val value: String, val description: String) {
+    @SerialName("Unconfirmed")
     UNCONFIRMED("Unconfirmed", "Transport is not confirmed"),
+
+    @SerialName("Acknowledged")
     ACKNOWLEDGED("Acknowledged", "Transport is confirmed. Equivalent to 'Acknowledgement' without severe 'eb:ErrorList/eb:HighestSeverity'"),
+
+    @SerialName("Rejected")
     REJECTED("Rejected", "Transport is rejected. Equivalent to 'MessageError' with 'eb:ErrorList/eb:HighestSeverity'=\"Error\""),
+
+    @SerialName("Unknown")
     UNKNOWN("Unknown", "The value is not supported");
 
     companion object {


### PR DESCRIPTION
_KotlinX_ decodes enums by enum constant name (or @SerialName), so it expects JSON like:

- "ACKNOWLEDGED" (matches the enum constant name)
…but the NHN API delivers:
- "Acknowledged" (matches the value property, not the enum constant name)

So when using the client we get: `does not contain element with name 'Acknowledged'`