### PR TITLE
Scale minimum pods to 2

### DIFF
--- a/.nais/edi-adapter-dev.yaml
+++ b/.nais/edi-adapter-dev.yaml
@@ -42,7 +42,7 @@ spec:
     timeout: 10
     failureThreshold: 10
   replicas:
-    min: 1
+    min: 2
     max: 4
     cpuThresholdPercentage: 50
   resources:


### PR DESCRIPTION
The Kubernetes autoscaler is scaling pods up and down from 1-2 continuously so we set minimum pods to 2.