### PR TITLE
Tilgang til edi-adapter for message-generator

### DIFF
--- a/.nais/edi-adapter-dev.yaml
+++ b/.nais/edi-adapter-dev.yaml
@@ -76,6 +76,8 @@ spec:
           cluster: dev-gcp
         - application: epj-simulator
           cluster: dev-gcp
+        - application: message-generator
+          cluster: dev-gcp
   env:
     - name: NHN_BASE_URL
       value: "https://api.tjener.test.melding.nhn.no"


### PR DESCRIPTION
Gitt tilgang til `edi-adapter` for `message-generator` så at generatoren kan sende innkommende meldinger på vegne av EPJ.

Oppgave: https://github.com/navikt/helsemelding-message-generator/issues/12