### PR TITLE
#55 Fjern senderHerId som request parameter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,5 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7.2.0
+        with:
+          commitish: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/edi-adapter-client/build.gradle.kts
+++ b/edi-adapter-client/build.gradle.kts
@@ -58,7 +58,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.helsemelding"
             artifactId = "edi-adapter-client"
-            version = "0.0.5"
+            version = "0.0.6"
             from(components["java"])
         }
     }

--- a/edi-adapter-model/build.gradle.kts
+++ b/edi-adapter-model/build.gradle.kts
@@ -43,7 +43,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.helsemelding"
             artifactId = "edi-adapter-model"
-            version = "0.0.4"
+            version = "0.0.5"
             from(components["java"])
         }
     }

--- a/edi-adapter-model/src/main/kotlin/no/nav/helsemelding/ediadapter/model/GetMessagesRequest.kt
+++ b/edi-adapter-model/src/main/kotlin/no/nav/helsemelding/ediadapter/model/GetMessagesRequest.kt
@@ -5,7 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class GetMessagesRequest(
     val receiverHerIds: List<Int>,
-    val senderHerId: Int? = null,
     val businessDocumentId: String? = null,
     val includeMetadata: Boolean = false,
     val messagesToFetch: Int = 10,
@@ -16,10 +15,6 @@ data class GetMessagesRequest(
 
         receiverHerIds.forEach {
             params += "receiverHerIds=$it"
-        }
-
-        senderHerId?.let {
-            params += "senderHerId=$it"
         }
 
         businessDocumentId?.let {

--- a/edi-adapter-server/src/main/kotlin/no/nav/helsemelding/ediadapter/server/Validation.kt
+++ b/edi-adapter-server/src/main/kotlin/no/nav/helsemelding/ediadapter/server/Validation.kt
@@ -30,9 +30,6 @@ fun Raise<ValidationError>.receiverHerIds(call: ApplicationCall): List<String> =
         .filter { it.isNotEmpty() }
         .also { ensure(it.isNotEmpty()) { ReceiverHerIdsEmpty } }
 
-fun Raise<ValidationError>.senderHerId(call: ApplicationCall): String? =
-    optionalNonBlankQueryParam(call, SENDER_HER_ID, SenderHerIdEmpty)
-
 fun Raise<ValidationError>.businessDocumentId(call: ApplicationCall): String? =
     optionalNonBlankQueryParam(call, BUSINESS_DOCUMENT_ID, BusinessDocumentIdEmpty)
 

--- a/edi-adapter-server/src/main/kotlin/no/nav/helsemelding/ediadapter/server/plugin/MessagesApi.kt
+++ b/edi-adapter-server/src/main/kotlin/no/nav/helsemelding/ediadapter/server/plugin/MessagesApi.kt
@@ -53,16 +53,6 @@ object MessagesApi {
                 }
             }
 
-            queryParameter<Int>("senderHerId") {
-                description = "Sender HER ID"
-
-                example("Sender HER ID") {
-                    summary = "Sender filter"
-                    description = "Filter messages by sender HER ID"
-                    value = 8142519
-                }
-            }
-
             queryParameter<String>("businessDocumentId") {
                 description = "Business document UUID"
 

--- a/edi-adapter-server/src/main/kotlin/no/nav/helsemelding/ediadapter/server/plugin/Routes.kt
+++ b/edi-adapter-server/src/main/kotlin/no/nav/helsemelding/ediadapter/server/plugin/Routes.kt
@@ -72,7 +72,6 @@ import no.nav.helsemelding.ediadapter.server.plugin.MessagesApi.postApprecDocs
 import no.nav.helsemelding.ediadapter.server.plugin.MessagesApi.postMessageDocs
 import no.nav.helsemelding.ediadapter.server.plugin.MessagesApi.postMshConfigurationDocs
 import no.nav.helsemelding.ediadapter.server.receiverHerIds
-import no.nav.helsemelding.ediadapter.server.senderHerId
 import no.nav.helsemelding.ediadapter.server.toContent
 import kotlin.uuid.Uuid
 import kotlinx.serialization.json.Json as JsonUtil
@@ -80,7 +79,6 @@ import kotlinx.serialization.json.Json as JsonUtil
 private val log = KotlinLogging.logger { }
 
 private const val RECEIVER_HER_IDS = "ReceiverHerIds"
-private const val SENDER_HER_ID = "SenderHerId"
 private const val BUSINESS_DOCUMENT_ID = "BusinessDocumentId"
 private const val INCLUDE_METADATA = "IncludeMetadata"
 private const val MESSAGES_TO_FETCH = "MessagesToFetch"
@@ -271,7 +269,6 @@ private fun Raise<ValidationError>.messageQueryParams(
     call: ApplicationCall
 ): Parameters {
     val receiverHerIds = receiverHerIds(call)
-    val senderHerId = senderHerId(call)
     val businessDocumentId = businessDocumentId(call)
     val includeMetadata = includeMetadata(call)
     val messagesToFetch = messagesToFetch(call)
@@ -279,7 +276,6 @@ private fun Raise<ValidationError>.messageQueryParams(
 
     return Parameters.build {
         appendAll(RECEIVER_HER_IDS, receiverHerIds)
-        appendIfPresent(SENDER_HER_ID, senderHerId)
         appendIfPresent(BUSINESS_DOCUMENT_ID, businessDocumentId)
         appendIfPresent(INCLUDE_METADATA, includeMetadata)
         appendIfPresent(MESSAGES_TO_FETCH, messagesToFetch)

--- a/edi-adapter-server/src/test/kotlin/no/nav/helsemelding/ediadapter/server/plugin/RoutesSpec.kt
+++ b/edi-adapter-server/src/test/kotlin/no/nav/helsemelding/ediadapter/server/plugin/RoutesSpec.kt
@@ -107,22 +107,6 @@ class RoutesSpec : StringSpec(
             }
         }
 
-        "GET /messages with receiver her id and sender her id returns EDI response" {
-            val ediClientV1 = fakeEdiClient {
-                it.url.fullPath shouldBe "/Messages?ReceiverHerIds=1&SenderHerId=2"
-                respond("""[{"id":"100", "receiverHerId": "1"}]""")
-            }
-
-            testApplication {
-                installExternalRoutes(ediClientV1)
-
-                val response = client.get("/api/v1/messages?receiverHerIds=1&senderHerId=2")
-
-                response.status shouldBe OK
-                response.bodyAsText() shouldBe """[{"id":"100", "receiverHerId": "1"}]"""
-            }
-        }
-
         "GET /messages with receiver her id and business document id returns EDI response" {
             val ediClientV1 = fakeEdiClient {
                 it.url.fullPath shouldBe "/Messages?ReceiverHerIds=1&BusinessDocumentId=10"


### PR DESCRIPTION
Fjernet `senderHerId `parameter fra `GET /messages` endepunkt både på server og klient siden.

Fikset også `release-drafter` workflow som pleide å kaste feil utenfor `main` branch.

Oppgave: https://github.com/navikt/helsemelding-edi-adapter/issues/55