### PR TITLE
Bugfix: Erstattet `role` med `senderRole` i `EbXmlInfo`

### DIFF
--- a/edi-adapter-client/build.gradle.kts
+++ b/edi-adapter-client/build.gradle.kts
@@ -58,7 +58,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.helsemelding"
             artifactId = "edi-adapter-client"
-            version = "0.0.7-SNAPSHOT-1"
+            version = "0.0.7"
             from(components["java"])
         }
     }

--- a/edi-adapter-client/build.gradle.kts
+++ b/edi-adapter-client/build.gradle.kts
@@ -58,7 +58,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.helsemelding"
             artifactId = "edi-adapter-client"
-            version = "0.0.6"
+            version = "0.0.7-SNAPSHOT-1"
             from(components["java"])
         }
     }

--- a/edi-adapter-model/build.gradle.kts
+++ b/edi-adapter-model/build.gradle.kts
@@ -43,7 +43,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.helsemelding"
             artifactId = "edi-adapter-model"
-            version = "0.0.6-SNAPSHOT-1"
+            version = "0.0.6"
             from(components["java"])
         }
     }

--- a/edi-adapter-model/build.gradle.kts
+++ b/edi-adapter-model/build.gradle.kts
@@ -43,7 +43,7 @@ publishing {
         create<MavenPublication>("mavenJava") {
             groupId = "no.nav.helsemelding"
             artifactId = "edi-adapter-model"
-            version = "0.0.5"
+            version = "0.0.6-SNAPSHOT-1"
             from(components["java"])
         }
     }

--- a/edi-adapter-model/src/main/kotlin/no/nav/helsemelding/ediadapter/model/EbXmlInfo.kt
+++ b/edi-adapter-model/src/main/kotlin/no/nav/helsemelding/ediadapter/model/EbXmlInfo.kt
@@ -9,7 +9,7 @@ data class EbXmlInfo(
     val service: String? = null,
     val serviceType: String? = null,
     val action: String? = null,
-    val role: String? = null,
+    val senderRole: String? = null,
     val useSenderLevel1HerId: Boolean? = null,
     val receiverRole: String? = null,
     val applicationName: String? = null,

--- a/edi-adapter-server/src/test/kotlin/no/nav/helsemelding/ediadapter/server/plugin/RoutesSpec.kt
+++ b/edi-adapter-server/src/test/kotlin/no/nav/helsemelding/ediadapter/server/plugin/RoutesSpec.kt
@@ -481,7 +481,7 @@ class RoutesSpec : StringSpec(
                     "service": "test-service",
                     "serviceType": "test-service-type",
                     "action": "test-action",
-                    "role": "test-sender-role",
+                    "senderRole": "test-sender-role",
                     "useSenderLevel1HerId": true,
                     "receiverRole": "test-receiver-role",
                     "applicationName": "test-application-name",


### PR DESCRIPTION
Ifølge [NHN sin dokumentasjon](https://utviklerportal.nhn.no/informasjonstjenester/meldingsutveksling/edi-20/edi-20-ekstern-docs/openapi/meldingstjener-api-test-v2-internett) skal feltet hete `senderRole`.
